### PR TITLE
Add list-tasks command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - A minimal Bash script is available as an experimental example; reference CLI for Bash completed.
 - New command `list-funcs` now caches results for faster repeated runs and stores the most common function in `most_common_function.txt`.
 - New command `list-diamonds` lists all tasks with `diamond` status.
+- New command `list-tasks` prints all tasks with their statuses.
 - `crystal:sync` keeps `crystallization.json` synchronized between the repo and `.vscode` for IDE integration.
 - Diamond rule: tasks reaching all KPI thresholds get `diamond` status.
 - Use `crystal:init` to "crystallize" any repository with a starter `crystallization.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,9 @@
 ### Changed
 
 - ROADMAP updated to reflect completed tasks
+
+## [0.3.15] - 2025-11-02
+
+### Added
+
+- `list-tasks` command in JS and Python CLIs to show all tasks with statuses

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 - **Python**: `python/crystallization_manager.py`
 - **Bash (experimental)**: `bash/crystallization_manager.sh`
 
-Все инструменты поддерживают одинаковые команды (`add-task`, `update-kpi`, `level`, `update-core`, `average`, `list-diamonds`, `list-funcs`, `sync`).
+Все инструменты поддерживают одинаковые команды (`add-task`, `update-kpi`, `level`, `update-core`, `average`, `list-diamonds`, `list-funcs`, `list-tasks`, `sync`).
 
 ### Diamond State / Алмазное состояние
 
@@ -87,6 +87,7 @@
 8. Запусти `npm run crystal:list-diamonds` чтобы увидеть все задачи, достигшие алмазного уровня
 9. Запусти `npm run crystal:sync` для синхронизации `crystallization.json` между репозиторием и IDE
 10. Запусти `npm test` чтобы выполнить юнит-тесты
+11. Запусти `npm run crystal:list-tasks` чтобы увидеть все текущие задачи и их статусы
 
 ## 🔄 Updating the Crystallization Badge
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,7 @@
 - [x] Add `list-funcs` command to analyze repository functions
 - [x] Optimize `list-funcs` performance with single-pass scanning
 - [x] Add `list-diamonds` command to display diamond tasks
+- [x] Add `list-tasks` command to show all tasks with statuses
 - [x] Provide `crystal:update-badge` script for automatic README badge refresh
 - [x] Provide `crystal:sync` script to synchronize `crystallization.json` with IDE
 - [x] Integrate linting and formatting tools

--- a/cli-implementations/js/crystallizationManager.ts
+++ b/cli-implementations/js/crystallizationManager.ts
@@ -274,6 +274,21 @@ yargs(hideBin(process.argv))
     }
   )
   .command(
+    'list-tasks',
+    'List all tasks with statuses',
+    () => {},
+    () => {
+      const data = loadData();
+      if (data.tasks.length === 0) {
+        console.log('No tasks found');
+        return;
+      }
+      data.tasks.forEach((t) => {
+        console.log(`${t.id}: ${t.title} [${t.status ?? 'unknown'}]`);
+      });
+    }
+  )
+  .command(
     'init',
     'Initialize crystallization in current repo',
     () => {},

--- a/cli-implementations/python/crystallization_manager.py
+++ b/cli-implementations/python/crystallization_manager.py
@@ -80,6 +80,17 @@ def list_diamonds(args):
         print(f"{t['id']}: {t['title']}")
 
 
+def list_tasks(args):
+    data = load_data()
+    tasks = data.get('tasks', [])
+    if not tasks:
+        print('No tasks found')
+        return
+    for t in tasks:
+        status = t.get('status', 'unknown')
+        print(f"{t['id']}: {t['title']} [{status}]")
+
+
 def init_repo(args):
     if DATA_FILE.exists():
         print('crystallization.json already exists')
@@ -125,6 +136,9 @@ avg.set_defaults(func=average)
 
 ld = sub.add_parser('list-diamonds')
 ld.set_defaults(func=list_diamonds)
+
+lt = sub.add_parser('list-tasks')
+lt.set_defaults(func=list_tasks)
 
 init_p = sub.add_parser('init')
 init_p.set_defaults(func=init_repo)


### PR DESCRIPTION
## Summary
- add `list-tasks` command to JS and Python CLIs
- document the new command in README and AGENTS guidelines
- update roadmap and changelog
- refresh crystallization badge

## Testing
- `npx prettier --write "**/*.{ts,js,json,md}"`
- `npm run lint`
- `npm test`
- `npm run crystal:avg`
- `npm run crystal:update-badge`


------
https://chatgpt.com/codex/tasks/task_b_685981cdedcc8320b177d131cba8b5a5